### PR TITLE
Add join code migration with corrected dependency

### DIFF
--- a/alembic/versions/c3a5d4e5f6a7_add_join_code_to_tournaments.py
+++ b/alembic/versions/c3a5d4e5f6a7_add_join_code_to_tournaments.py
@@ -1,0 +1,23 @@
+"""add join code to tournaments
+
+Revision ID: c3a5d4e5f6a7
+Revises: 908cf7ecefe9
+Create Date: 2025-09-13 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'c3a5d4e5f6a7'
+down_revision = '908cf7ecefe9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('tournaments', sa.Column('join_code', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('tournaments', 'join_code')


### PR DESCRIPTION
## Summary
- add migration to support join codes for tournaments
- set down revision to `908cf7ecefe9` for linear history

## Testing
- `alembic history --verbose`
- `pytest -q` *(fails: TestAmericanoTournament.test_performance_scalability)*

------
https://chatgpt.com/codex/tasks/task_e_68c692e61f488332a84a487cff6d5438